### PR TITLE
g_spectateBots dvar + prevent build failure

### DIFF
--- a/code/functions.hpp
+++ b/code/functions.hpp
@@ -2199,6 +2199,24 @@ static const SV_ClientThink_t SV_ClientThink = (SV_ClientThink_t)0x08090D18;
 static const SV_ClientThink_t SV_ClientThink = (SV_ClientThink_t)0x08090DAC;
 #endif
 
+typedef int (*SV_GetArchivedClientInfo_t)(int clientNum, int *pArchiveTime, playerState_t *ps, clientState_t *cs);
+#if COD_VERSION == COD2_1_0
+static const SV_GetArchivedClientInfo_t SV_GetArchivedClientInfo = (SV_GetArchivedClientInfo_t)0x0; // Not tested
+#elif COD_VERSION == COD2_1_2
+static const SV_GetArchivedClientInfo_t SV_GetArchivedClientInfo = (SV_GetArchivedClientInfo_t)0x0; // Not tested
+#elif COD_VERSION == COD2_1_3
+static const SV_GetArchivedClientInfo_t SV_GetArchivedClientInfo = (SV_GetArchivedClientInfo_t)0x0809a0b6;
+#endif
+
+typedef qboolean (*G_ClientCanSpectateTeam_t)(gclient_s *client, int team);
+#if COD_VERSION == COD2_1_0
+static const G_ClientCanSpectateTeam_t G_ClientCanSpectateTeam = (G_ClientCanSpectateTeam_t)0x0; // Not tested
+#elif COD_VERSION == COD2_1_2
+static const G_ClientCanSpectateTeam_t G_ClientCanSpectateTeam = (G_ClientCanSpectateTeam_t)0x0; // Not tested
+#elif COD_VERSION == COD2_1_3
+static const G_ClientCanSpectateTeam_t G_ClientCanSpectateTeam = (G_ClientCanSpectateTeam_t)0x080f6dd0;
+#endif
+
 typedef void (*SV_Heartbeat_f_t)(void);
 #if COD_VERSION == COD2_1_0
 static const SV_Heartbeat_f_t SV_Heartbeat_f = (SV_Heartbeat_f_t)0x0; // Not tested

--- a/code/gsc_entity.cpp
+++ b/code/gsc_entity.cpp
@@ -2,6 +2,8 @@
 
 #if COMPILE_ENTITY == 1
 
+extern customPlayerState_t customPlayerState[MAX_CLIENTS];
+
 void gsc_entity_setalive(scr_entref_t ref)
 {
 	int id = ref.entnum;


### PR DESCRIPTION
Hello

This pull requests fixes a build failure by declaring `customPlayerState` in _gsc_entity.cpp_

And it adds a `g_spectateBots` dvar to be able to prevent players from spectating bots (it's `true` by default, for the stock behavior to remain)

The `custom_Cmd_FollowCycle_f` definition got obtained from the _CoD2rev_Server_ source code

Please let me know if there are any changes needed for this pull request to be merged
Regards