### PR TITLE
download stuck issue fix

### DIFF
--- a/code/libcod.cpp
+++ b/code/libcod.cpp
@@ -8976,7 +8976,8 @@ void custom_SV_ExecuteClientMessage(client_t *cl, msg_t *msg)
 	}
 
 	if ( (cl->serverId == sv_serverId_value || cl->downloadName[0])
-		|| (!cl->downloadName[0] && strstr(cl->lastClientCommandString, "nextdl")) )
+		|| (!cl->downloadName[0] && strstr(cl->lastClientCommandString, "nextdl"))
+		|| cl->clientDownloadingWWW )
 	{
 		do {
 			c = MSG_ReadBits(&decompressMsg, 3);

--- a/code/libcod.cpp
+++ b/code/libcod.cpp
@@ -8975,7 +8975,8 @@ void custom_SV_ExecuteClientMessage(client_t *cl, msg_t *msg)
 		return;
 	}
 
-	if ( cl->serverId == sv_serverId_value || cl->downloadName[0] )
+	if ( (cl->serverId == sv_serverId_value || cl->downloadName[0])
+		|| (!cl->downloadName[0] && strstr(cl->lastClientCommandString, "nextdl")) )
 	{
 		do {
 			c = MSG_ReadBits(&decompressMsg, 3);
@@ -9012,15 +9013,7 @@ void custom_SV_ExecuteClientMessage(client_t *cl, msg_t *msg)
 		} while ( cl->state != CS_ZOMBIE );
 		LargeLocalDestructor(&buf);
 	}
-	else if ( (cl->serverId & 0xF0) == (sv_serverId_value & 0xF0) )
-	{
-		if ( cl->state == CS_PRIMED )
-		{
-			SV_ClientEnterWorld(cl, &cl->lastUsercmd);
-		}
-		LargeLocalDestructor(&buf);
-	}
-	else
+	else if ( (cl->serverId & 0xF0) != (sv_serverId_value & 0xF0) )
 	{
 		if ( cl->gamestateMessageNum < cl->messageAcknowledge )
 		{

--- a/code/libcod.cpp
+++ b/code/libcod.cpp
@@ -9014,7 +9014,15 @@ void custom_SV_ExecuteClientMessage(client_t *cl, msg_t *msg)
 		} while ( cl->state != CS_ZOMBIE );
 		LargeLocalDestructor(&buf);
 	}
-	else if ( (cl->serverId & 0xF0) != (sv_serverId_value & 0xF0) )
+	else if ( (cl->serverId & 0xF0) == (sv_serverId_value & 0xF0) )
+	{
+		if ( cl->state == CS_PRIMED )
+		{
+			SV_ClientEnterWorld(cl, &cl->lastUsercmd);
+		}
+		LargeLocalDestructor(&buf);
+	}
+	else
 	{
 		if ( cl->gamestateMessageNum < cl->messageAcknowledge )
 		{


### PR DESCRIPTION
Hello

This pull request fixes a download stuck issue
___
Here is how to reproduce the issue:

- Have two referenced .iwd files in the `fs_game` folder
- Client joins server, file 1 download is in progress
- Server executes a `fast_restart` command
- Client file 1 download complete
- Client file 2 download not starting
___

It occurs with "slow" download and with http downloading too when `sv_wwwDlDisconnected 0`

This issue is fixed in the Quake-III-Arena repo with these explanations:

![Screenshot 2024-05-31 023124](https://github.com/ibuddieat/zk_libcod/assets/143759274/7ba1b9b7-072a-46d3-87d2-96dfceb4703e)

The `SV_ExecuteClientMessage` of IW was probably obtained before the fix

Please let me know if there are any changes needed for this pull request to be merged
Regards